### PR TITLE
Update slider_float call for imgui v1.78+

### DIFF
--- a/imgui_datascience/_imgui_cv_zoom.py
+++ b/imgui_datascience/_imgui_cv_zoom.py
@@ -305,11 +305,11 @@ def image_explorer_impl(
             imgui.push_item_width(80)
             # noinspection PyArgumentList
             changed, im.image_adjustments.factor = imgui.slider_float(
-                imgui_ext.make_unique_label("k"), im.image_adjustments.factor, 0., 32., format="%.3f", power=5.)
+                imgui_ext.make_unique_label("k"), im.image_adjustments.factor, 0., 32., format="%.3f", flags=(1<<4) | (1<<5))
             imgui.same_line()
             imgui.push_item_width(80)
             changed, im.image_adjustments.delta = imgui.slider_float(
-                imgui_ext.make_unique_label("delta"), im.image_adjustments.delta, 0., 255., format="%.3f", power=5.)
+                imgui_ext.make_unique_label("delta"), im.image_adjustments.delta, 0., 255., format="%.3f", flags=(1<<4) | (1<<5))
             imgui.same_line()
             if not im.image_adjustments.is_none():
                 if imgui.small_button(imgui_ext.make_unique_label("reset")):


### PR DESCRIPTION
[Imgui handles slider differently starting v1.78 onwards](https://github.com/ocornut/imgui/issues/3361 ), depreciating entirely the power argument. This PR updates the calls for the new imgui API.

Apps running on both pyimgui@master (2022/04/04) and pygame are still broken. [Those will work again with the upcoming v2.0](https://github.com/pyimgui/pyimgui/issues/210#issuecomment-1036571753). Combined with this PR, **imgui_datascience** can still be used with the latest version of these libraries.